### PR TITLE
Fix PHPDoc type annotations

### DIFF
--- a/src/Messages/SlackMessage.php
+++ b/src/Messages/SlackMessage.php
@@ -235,7 +235,7 @@ class SlackMessage
     /**
      * Unfurl links to rich display.
      *
-     * @param  string  $unfurl
+     * @param  bool  $unfurl
      * @return $this
      */
     public function unfurlLinks($unfurl)
@@ -248,7 +248,7 @@ class SlackMessage
     /**
      * Unfurl media to rich display.
      *
-     * @param  string  $unfurl
+     * @param  bool  $unfurl
      * @return $this
      */
     public function unfurlMedia($unfurl)


### PR DESCRIPTION
Both `SlackMessage::unfurlLinks` and `SlackMessage::unfurlMedia` have boolean types, but PHPDoc for their setters use `string` type.